### PR TITLE
update from old missing CDN ui-bootstrap to an current

### DIFF
--- a/src/SbManager/SbManager.csproj
+++ b/src/SbManager/SbManager.csproj
@@ -263,30 +263,30 @@
     </Content>
     <None Include="Content\bootstrap-theme.css.map" />
     <None Include="Content\bootstrap.css.map" />
-    <None Include="Content\font\sbmanagerfont.eot">
+    <Content Include="Content\font\sbmanagerfont.eot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Content\font\sbmanagerfont.otf">
+    </Content>
+    <Content Include="Content\font\sbmanagerfont.otf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Content\font\sbmanagerfont.svg">
+    </Content>
+    <Content Include="Content\font\sbmanagerfont.svg">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Content\font\sbmanagerfont.ttf">
+    </Content>
+    <Content Include="Content\font\sbmanagerfont.ttf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="Content\font\sbmanagerfont.woff">
+    </Content>
+    <Content Include="Content\font\sbmanagerfont.woff">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="fonts\glyphicons-halflings-regular.eot">
+    </Content>
+    <Content Include="fonts\glyphicons-halflings-regular.eot">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="fonts\glyphicons-halflings-regular.ttf">
+    </Content>
+    <Content Include="fonts\glyphicons-halflings-regular.ttf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="fonts\glyphicons-halflings-regular.woff">
+    </Content>
+    <Content Include="fonts\glyphicons-halflings-regular.woff">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    </Content>
     <None Include="SbManager.nuspec" />
     <None Include="packages.config" />
     <Content Include="Content\tmpl\manager\home.html">

--- a/src/SbManager/SbManager.nuspec
+++ b/src/SbManager/SbManager.nuspec
@@ -9,5 +9,8 @@
         <projectUrl>http://it.wiki.gxs.com.au/</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Service Bus Manager</description>
+		<files>
+			<file src="bin\Release\*" target="" />
+		</files>
     </metadata>
 </package>

--- a/src/SbManager/SbManager.nuspec
+++ b/src/SbManager/SbManager.nuspec
@@ -9,8 +9,8 @@
         <projectUrl>http://it.wiki.gxs.com.au/</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Service Bus Manager</description>
-		<files>
-			<file src="bin\Release\*" target="" />
-		</files>
     </metadata>
+	<files>
+		<file src="bin\Release\*" target="" />
+	</files>
 </package>

--- a/src/SbManager/SbManager.nuspec
+++ b/src/SbManager/SbManager.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>SbManager</id>
-        <version>1.2.0.0</version>
+        <version>$version$</version>
         <title>SbManager</title>
         <authors>GlobalX DevX, Luke Schafer</authors>
         <owners>GlobalX DevX</owners>

--- a/src/SbManager/Views/master.html
+++ b/src/SbManager/Views/master.html
@@ -9,8 +9,8 @@
     <link rel="stylesheet" href="/Content/font/sbmanagerfont.css" />
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.18/angular.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.18/angular-route.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.10.0/ui-bootstrap.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.10.0/ui-bootstrap-tpls.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.12.1/ui-bootstrap.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.12.1/ui-bootstrap-tpls.min.js"></script>
     <script src="/Scripts/jquery-2.1.0.min.js"></script>
     <script src="/Scripts/manager/manager.js"></script>
     <script src="/Scripts/manager/directives.js"></script>


### PR DESCRIPTION
Requires setting the build to release in appveyor:

![appveyor_release_build](https://cloud.githubusercontent.com/assets/980396/7907229/3819221e-087a-11e5-822f-5c35a911ab9e.PNG)


Additionally, this PR includes changing the nuspec file to auto-version, and I updated the auto assembly patching in my appveyor build. You can find that info here http://www.daveaglick.com/posts/deploying-a-public-nuget-package-from-scratch 