### PR TITLE
make a space between the icon and scheduled text

### DIFF
--- a/src/SbManager/Content/tmpl/directives/messagingEntity.html
+++ b/src/SbManager/Content/tmpl/directives/messagingEntity.html
@@ -40,7 +40,7 @@
             </div>
             <div class="panel-body">
                 <h2>
-                    <i class="glyphicon glyphicon-time"></i>
+                    <span message-type-icon message-type="messageTypes.scheduled" />
                     {{model.ScheduledMessageCount}}
                 </h2>
             </div>

--- a/src/SbManager/Content/tmpl/directives/peek.html
+++ b/src/SbManager/Content/tmpl/directives/peek.html
@@ -2,7 +2,7 @@
     <div ng-class="{'col-lg-12' : messages.length == 0, 'col-lg-6' : messages.length != 0 }">
         <div class="panel" ng-class="{'panel-success': messageType === messageTypes.active, 'panel-danger': messageType === messageTypes.dead, 'panel-info': messageType === messageTypes.scheduled}">
             <div class="panel-heading">
-                <h3 class="panel-title"><span message-type-icon message-type="messageType"/>Peek {{messageTypeDescription}}</h3>
+                <h3 class="panel-title"><span message-type-icon message-type="messageType"/> Peek {{messageTypeDescription}}</h3>
             </div>
             <div class="panel-footer">
                 <strong>Top: </strong>


### PR DESCRIPTION
RE: Peek on Scheduled Messages

There was an inconsistency with the spacing between the time icon and the Scheduled Message title

The problem is that the height of the time icon is smaller than deadletter's and active's and because the icon's span's height and width are auto-assign this gets a different look.

A dirty fix for it all to look the same is to prefix the spacing.
Rather than putting if statements which would make the template a little nastier looking.
The view for all three messages look the same with this.