### PR TITLE
Add a filter to the overview screen to show only the topics and queues with deadletters

### DIFF
--- a/src/SbManager/Content/tmpl/manager/home.html
+++ b/src/SbManager/Content/tmpl/manager/home.html
@@ -8,17 +8,38 @@
     <loading ng-if="!model"></loading>
 
     <div ng-if="model">
+        <div class="row" ng-if="model.TotalDeadLetters > 0">
+            <div class="panel">
+                <div class="panel-body">
+                    <div>
+                        <span message-type-icon message-type="messageTypes.dead" />
+                        <span ng-if="model.TotalDeadLetters == 1">There is currently 1 deadletter.</span>
+                        <span ng-if="model.TotalDeadLetters > 1">There are currently {{model.TotalDeadLetters}} deadletters.</span>
+                    </div>
+                    <div>
+                        <a href="" ng-if="!deadletterFilterEnabled" ng-click="toggleDeadletterFilter()">Show only queues and topics containing deadletters</a>
+                        <a href="" ng-if="deadletterFilterEnabled" ng-click="toggleDeadletterFilter()">Show all queues and topics</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col-lg-6">
                 <h2>Queues</h2>
                 <ul class="entitylist">
-                    <li ng-repeat="m in model.Queues"><i class="glyphicon glyphicon-th-list"></i> <a href="#/queue/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" /></li>
+                    <li ng-repeat="m in model.Queues" ng-if="!deadletterFilterEnabled || m.DeadLetterCount > 0">
+                        <i class="glyphicon glyphicon-th-list"></i> <a href="#/queue/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" />
+                    </li>
                 </ul>
             </div>
             <div class="col-lg-6">
                 <h2>Topics</h2>
                 <ul class="entitylist">
-                    <li ng-repeat="m in model.Topics"><i class="glyphicon glyphicon-th"></i> <a href="#/topic/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" /></li>
+                    <li ng-repeat="m in model.Topics" ng-if="!deadletterFilterEnabled || m.DeadLetterCount > 0">
+                        <i class="glyphicon glyphicon-th"></i> <a href="#/topic/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" />
+                    </li>
+
                 </ul>
             </div>
         </div>

--- a/src/SbManager/Scripts/manager/homeController.js
+++ b/src/SbManager/Scripts/manager/homeController.js
@@ -1,6 +1,8 @@
-﻿$app.controller('homeController', ['$scope', function ($scope) {
+﻿$app.controller('homeController', ['$scope', 'messageTypeConstants', function ($scope, messageTypeConstants) {
+    $scope.messageTypes = messageTypeConstants;
     $scope.refresh = function () {
         $scope.model = null;
+        $scope.deadletterFilterEnabled = false;
         $.ajax({
             url: window.applicationBasePath + "/api/v1/busmanager/",
             dataType: 'json',
@@ -31,4 +33,8 @@
             $scope.refresh();
         });
     };
+
+    $scope.toggleDeadletterFilter = function () {
+        $scope.deadletterFilterEnabled = !$scope.deadletterFilterEnabled;
+    }
 }]);


### PR DESCRIPTION
Add a filter to the overview screen to show only the topics and queues with deadletters
![sbmanager filter 1](https://cloud.githubusercontent.com/assets/7269931/23532825/681cfc24-fff9-11e6-846d-32b7823f5931.png)
![sbmanager filter 2](https://cloud.githubusercontent.com/assets/7269931/23532826/681ebe42-fff9-11e6-982b-8a5fc3a09f69.png)

