### PR TITLE
Add a new route to show only queues/topics containing deadletters

### DIFF
--- a/src/SbManager/Content/tmpl/manager/deadletters.html
+++ b/src/SbManager/Content/tmpl/manager/deadletters.html
@@ -1,0 +1,30 @@
+﻿<div class="container">
+    <ul class="breadcrumb">
+        <li class="active">Deadletters</li>
+    </ul>
+
+    <h1 id="type"><i class="sbmicon sbmicon-logo"></i> SbManager</h1>
+
+    <loading ng-if="!model"></loading>
+
+    <div ng-if="model">
+        <div class="row">
+            <div class="col-lg-6">
+                <h2>Queues ({{queuesWithDeadlettersCount}}/{{model.Queues.length}})</h2>
+                <ul class="entitylist">
+                    <li ng-repeat="m in model.Queues" ng-if="m.DeadLetterCount > 0">
+                        <i class="glyphicon glyphicon-th-list"></i> <a href="#/queue/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" />
+                    </li>
+                </ul>
+            </div>
+            <div class="col-lg-6">
+                <h2>Topics ({{topicsWithDeadlettersCount}}/{{model.Topics.length}})</h2>
+                <ul class="entitylist">
+                    <li ng-repeat="m in model.Topics" ng-if="m.DeadLetterCount > 0">
+                        <i class="glyphicon glyphicon-th"></i> <a href="#/topic/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" />
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/SbManager/Content/tmpl/manager/home.html
+++ b/src/SbManager/Content/tmpl/manager/home.html
@@ -1,7 +1,6 @@
 ﻿<div class="container">
     <ul class="breadcrumb">
-        <li ng-if="!deadletterFilterEnabled" class="active">Overview</li>
-        <li ng-if="deadletterFilterEnabled" class="active">Deadletters</li>
+        <li class="active">Overview</li>
     </ul>
 
     <h1 id="type"><i class="sbmicon sbmicon-logo"></i> SbManager</h1>
@@ -11,24 +10,20 @@
     <div ng-if="model">
         <div class="row">
             <div class="col-lg-6">
-                <h2>Queues<span ng-if="deadletterFilterEnabled"> ({{queuesWithDeadlettersCount}}/{{model.Queues.length}})</span></h2>
+                <h2>Queues</h2>
                 <ul class="entitylist">
-                    <li ng-repeat="m in model.Queues" ng-if="!deadletterFilterEnabled || m.DeadLetterCount > 0">
-                        <i class="glyphicon glyphicon-th-list"></i> <a href="#/queue/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" />
-                    </li>
+                    <li ng-repeat="m in model.Queues"><i class="glyphicon glyphicon-th-list"></i> <a href="#/queue/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" /></li>
                 </ul>
             </div>
             <div class="col-lg-6">
-                <h2>Topics<span ng-if="deadletterFilterEnabled"> ({{topicsWithDeadlettersCount}}/{{model.Topics.length}})</span></h2>
+                <h2>Topics</h2>
                 <ul class="entitylist">
-                    <li ng-repeat="m in model.Topics" ng-if="!deadletterFilterEnabled || m.DeadLetterCount > 0">
-                        <i class="glyphicon glyphicon-th"></i> <a href="#/topic/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" />
-                    </li>
-
+                    <li ng-repeat="m in model.Topics"><i class="glyphicon glyphicon-th"></i> <a href="#/topic/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" /></li>
                 </ul>
             </div>
         </div>
     </div>
+</div>
 
     <div class="navbar navbar-fixed-bottom navbar-default bottom-bar" role="navigation">
         <nav class="container">

--- a/src/SbManager/Content/tmpl/manager/home.html
+++ b/src/SbManager/Content/tmpl/manager/home.html
@@ -1,6 +1,7 @@
 ﻿<div class="container">
     <ul class="breadcrumb">
-        <li class="active">Overview</li>
+        <li ng-if="!deadletterFilterEnabled" class="active">Overview</li>
+        <li ng-if="deadletterFilterEnabled" class="active">Deadletters</li>
     </ul>
 
     <h1 id="type"><i class="sbmicon sbmicon-logo"></i> SbManager</h1>
@@ -10,27 +11,31 @@
     <div ng-if="model">
         <div class="row">
             <div class="col-lg-6">
-                <h2>Queues</h2>
+                <h2>Queues<span ng-if="deadletterFilterEnabled"> ({{queuesWithDeadlettersCount}}/{{model.Queues.length}})</span></h2>
                 <ul class="entitylist">
-                    <li ng-repeat="m in model.Queues"><i class="glyphicon glyphicon-th-list"></i> <a href="#/queue/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" /></li>
+                    <li ng-repeat="m in model.Queues" ng-if="!deadletterFilterEnabled || m.DeadLetterCount > 0">
+                        <i class="glyphicon glyphicon-th-list"></i> <a href="#/queue/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" />
+                    </li>
                 </ul>
             </div>
             <div class="col-lg-6">
-                <h2>Topics</h2>
+                <h2>Topics<span ng-if="deadletterFilterEnabled"> ({{topicsWithDeadlettersCount}}/{{model.Topics.length}})</span></h2>
                 <ul class="entitylist">
-                    <li ng-repeat="m in model.Topics"><i class="glyphicon glyphicon-th"></i> <a href="#/topic/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" /></li>
+                    <li ng-repeat="m in model.Topics" ng-if="!deadletterFilterEnabled || m.DeadLetterCount > 0">
+                        <i class="glyphicon glyphicon-th"></i> <a href="#/topic/{{m.Name}}">{{m.Name}}</a> <queuelength class="pull-right" active="{{m.ActiveMessageCount}}" dead="{{m.DeadLetterCount}}" scheduled="{{m.ScheduledMessageCount}}" />
+                    </li>
+
                 </ul>
             </div>
         </div>
     </div>
-</div>
 
-<div class="navbar navbar-fixed-bottom navbar-default bottom-bar" role="navigation">
-    <nav class="container">
-        <ul class="nav navbar-nav" ng-if="model">
-            <li><button class="btn btn-success" ng-click="refresh()"><i class="glyphicon glyphicon-refresh btn-sm"></i> Refresh</button></li>
-            <li><button class="btn btn-danger" ng-click="deleteAllDeadLetters()"><i class="glyphicon glyphicon-remove btn-sm"></i> Delete all Dead Letters</button></li>
-            <li class="hidden-xs"><button class="btn btn-danger" ng-click="deleteAll()"><i class="glyphicon glyphicon-remove btn-sm"></i> Delete all</button></li>
-        </ul>
-    </nav>
-</div>
+    <div class="navbar navbar-fixed-bottom navbar-default bottom-bar" role="navigation">
+        <nav class="container">
+            <ul class="nav navbar-nav" ng-if="model">
+                <li><button class="btn btn-success" ng-click="refresh()"><i class="glyphicon glyphicon-refresh btn-sm"></i> Refresh</button></li>
+                <li><button class="btn btn-danger" ng-click="deleteAllDeadLetters()"><i class="glyphicon glyphicon-remove btn-sm"></i> Delete all Dead Letters</button></li>
+                <li class="hidden-xs"><button class="btn btn-danger" ng-click="deleteAll()"><i class="glyphicon glyphicon-remove btn-sm"></i> Delete all</button></li>
+            </ul>
+        </nav>
+    </div>

--- a/src/SbManager/SbManager.csproj
+++ b/src/SbManager/SbManager.csproj
@@ -275,6 +275,9 @@
     <Content Include="Content\tmpl\directives\queuelength.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Content\tmpl\manager\deadletters.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Content\tmpl\manager\queue.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/SbManager/Scripts/manager/homeController.js
+++ b/src/SbManager/Scripts/manager/homeController.js
@@ -1,11 +1,17 @@
-﻿$app.controller('homeController', ['$scope', function ($scope) {
+﻿$app.controller('homeController', ['$scope', '$route', '_', function ($scope, $route, _) {
+
+    $scope.deadletterFilterEnabled = $route.current.$$route.deadletterFilter;
+
     $scope.refresh = function () {
         $scope.model = null;
+
         $.ajax({
             url: window.applicationBasePath + "/api/v1/busmanager/",
             dataType: 'json',
             success: function(d) {
                 $scope.model = d;
+                $scope.queuesWithDeadlettersCount = d.Queues.reduce((c, q) => c + (q.DeadLetterCount ? 1 : 0), 0);
+                $scope.topicsWithDeadlettersCount = d.Topics.reduce((c, t) => c + (t.DeadLetterCount ? 1 : 0), 0);
                 $scope.$digest();
             },
             error: function (jqXHR) {

--- a/src/SbManager/Scripts/manager/manager.js
+++ b/src/SbManager/Scripts/manager/manager.js
@@ -12,7 +12,7 @@ $app.config(function ($routeProvider) {
 		})
 
         .when('/deadletters', {
-            templateUrl: window.applicationBasePath + '/Content/tmpl/manager/home.html',
+            templateUrl: window.applicationBasePath + '/Content/tmpl/manager/deadletters.html',
             controller: 'homeController',
             deadletterFilter: true
         })

--- a/src/SbManager/Scripts/manager/manager.js
+++ b/src/SbManager/Scripts/manager/manager.js
@@ -11,6 +11,12 @@ $app.config(function ($routeProvider) {
 		    controller: 'homeController'
 		})
 
+        .when('/deadletters', {
+            templateUrl: window.applicationBasePath + '/Content/tmpl/manager/home.html',
+            controller: 'homeController',
+            deadletterFilter: true
+        })
+
 		.when('/help', {
 		    templateUrl: window.applicationBasePath + '/Content/tmpl/manager/help.html',
 		    controller: 'helpController'

--- a/src/SbManager/Views/master.html
+++ b/src/SbManager/Views/master.html
@@ -38,6 +38,7 @@
         <ul class="nav navbar-nav">
             <li class="active"><a href="#/"><i class="sbmicon sbmicon-logo"></i> SbManager</a></li>
             <li><a href="#/">Home</a></li>
+            <li><a href="#/deadletters">Deadletters</a></li>
             <li><a href="#/help">Help</a></li>
         </ul>
     </nav>


### PR DESCRIPTION
An alternative to https://github.com/GlobalX/SbManager/pull/79 is to add a new route '/deadletters' to show only the queues/topics containing deadletters. The home screen is not changed. (Good suggestion from @drewfreyling )