### PR TITLE
Less prominent 'Removal all' button and 'Deadletter all' should be a warning colored

### DIFF
--- a/src/SbManager/Content/site.css
+++ b/src/SbManager/Content/site.css
@@ -18,6 +18,7 @@ ul.entitylist li:hover { background-color: #253544; }
 
 .peek-btn { width: 100px; display: inline-block; vertical-align:middle; }
 .search-btn  { width: 200px; display: inline-block; vertical-align:middle; }
+.remove-all-btn { margin-bottom: 20px }
 
 .message-body { width:100%; height: 150px; }
 .breakout-text-sm { width:100%; height: 50px; }
@@ -36,7 +37,6 @@ button i.glyphicon { padding-left: 0;}
 .bottom-bar { height: 46px; border-top: solid 3px #2b3e50; }
 .bottom-bar .navbar-nav { margin: 0;}
 .bottom-bar .navbar-nav>li { float: left;}
-
 
 .sbmicon {
   position: relative;

--- a/src/SbManager/Content/site.css
+++ b/src/SbManager/Content/site.css
@@ -20,6 +20,8 @@ ul.entitylist li:hover { background-color: #253544; }
 .search-btn  { width: 200px; display: inline-block; vertical-align:middle; }
 .remove-all-btn { margin-bottom: 20px }
 
+.centered-panel { text-align: center }
+
 .message-body { width:100%; height: 150px; }
 .breakout-text-sm { width:100%; height: 50px; }
 .breakout-text-lg { width:100%; height: 400px; }

--- a/src/SbManager/Content/tmpl/directives/messagingEntity.html
+++ b/src/SbManager/Content/tmpl/directives/messagingEntity.html
@@ -12,7 +12,7 @@
             </div>
             <div ng-if="model.ActiveMessageCount > 0 && !model.Subscriptions" class="panel-footer">
                 <button ng-if="removeall" ng-click="removeall(false)" type="button" class="btn-xs btn-danger remove-all-btn">Remove all</button>
-                <button ng-if="deadletterall" ng-click="deadletterall()" type="button" class="btn btn-danger">DeadLetter all</button>
+                <button ng-if="deadletterall" ng-click="deadletterall()" type="button" class="btn btn-warning">DeadLetter all</button>
             </div>
         </div>
     </div>

--- a/src/SbManager/Content/tmpl/directives/messagingEntity.html
+++ b/src/SbManager/Content/tmpl/directives/messagingEntity.html
@@ -10,7 +10,7 @@
                     {{model.ActiveMessageCount}}
                 </h2>
             </div>
-            <div ng-if="model.ActiveMessageCount > 0 && !model.Subscriptions" class="panel-footer">
+            <div ng-if="model.ActiveMessageCount > 0 && !model.Subscriptions" class="panel-footer centered-panel">
                 <button ng-if="removeall" ng-click="removeall(false)" type="button" class="btn-xs btn-danger remove-all-btn">Remove all</button>
                 <button ng-if="deadletterall" ng-click="deadletterall()" type="button" class="btn btn-warning">DeadLetter all</button>
             </div>
@@ -27,7 +27,7 @@
                     {{model.DeadLetterCount}}
                 </h2>
             </div>
-            <div ng-if="model.DeadLetterCount > 0 && !model.Subscriptions" class="panel-footer">
+            <div ng-if="model.DeadLetterCount > 0 && !model.Subscriptions" class="panel-footer centered-panel">
                 <button ng-if="removeall" ng-click="removeall(true)" type="button" class="btn-xs btn-danger remove-all-btn">Remove all</button>
                 <button ng-if="requeue" ng-click="requeue()" type="button" class="btn btn-warning">Requeue all</button>
             </div>

--- a/src/SbManager/Content/tmpl/directives/messagingEntity.html
+++ b/src/SbManager/Content/tmpl/directives/messagingEntity.html
@@ -11,7 +11,7 @@
                 </h2>
             </div>
             <div ng-if="model.ActiveMessageCount > 0 && !model.Subscriptions" class="panel-footer">
-                <button ng-if="removeall" ng-click="removeall(false)" type="button" class="btn btn-danger">Remove all</button>
+                <button ng-if="removeall" ng-click="removeall(false)" type="button" class="btn-xs btn-danger remove-all-btn">Remove all</button>
                 <button ng-if="deadletterall" ng-click="deadletterall()" type="button" class="btn btn-danger">DeadLetter all</button>
             </div>
         </div>
@@ -28,7 +28,7 @@
                 </h2>
             </div>
             <div ng-if="model.DeadLetterCount > 0 && !model.Subscriptions" class="panel-footer">
-                <button ng-if="removeall" ng-click="removeall(true)" type="button" class="btn btn-danger">Remove all</button>
+                <button ng-if="removeall" ng-click="removeall(true)" type="button" class="btn-xs btn-danger remove-all-btn">Remove all</button>
                 <button ng-if="requeue" ng-click="requeue()" type="button" class="btn btn-warning">Requeue all</button>
             </div>
         </div>


### PR DESCRIPTION
The following change:
- Makes the 'Remove all' button smaller and separated from 'Requeue All' and 'Deadletter All'.  This is so 
 that the destructive operation is less likely to be clicked by accident.  (It could be stated that there is a confirmation dialog to help prevent this, but as the dialog always appears for 'Requeue all', it can be easy to get into the habit of ignoring it)
- Changes the css class of Deadletter all from btn-danger to btn-warning as deadlettering is not a destructive operation.


Before:
![image](https://user-images.githubusercontent.com/3528836/27855298-5329b35a-61ad-11e7-829a-2619cf86a777.png)

After:
![image](https://user-images.githubusercontent.com/3528836/27855185-d0fd09d6-61ac-11e7-9cc4-52a3ff35f153.png)