### PR TITLE
:sparkles: add api to retrieve summary of deadletters

### DIFF
--- a/src/SbManager.Tests/Models/ViewModelBuilders/DeadletterVIewBuilderTests.cs
+++ b/src/SbManager.Tests/Models/ViewModelBuilders/DeadletterVIewBuilderTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NSubstitute;
+using NUnit.Framework;
+using SbManager.BusHelpers;
+using SbManager.Models.ViewModelBuilders;
+using SbManager.Models.ViewModels;
+using Shouldly;
+using TestStack.BDDfy;
+
+namespace SbManager.Tests.Models.ViewModelBuilders
+{
+    [TestFixture]
+    public class DeadletterVIewBuilderTests
+    {
+        private IBusMonitor _busMonitor;
+        public string FakeUrl = "http://url";
+        private DeadletterView _result;
+        private DeadletterViewBuilder _builder;
+        [Test]
+        public void CanListDeadLettersFromSubscriptionsAndQueues()
+        {
+            this.Given(x => x.GivenABuilder())
+                .And(x => x.GivenThatTheBusMonitorReturnsAnOverview())
+                .When(x => x.WhenBuildingModel())
+                .Then(x => x.ThenDeadlettersAreReturned())
+                .BDDfy();
+        }
+
+        void GivenABuilder()
+        {
+            _busMonitor = Substitute.For<IBusMonitor>();
+            var config = Substitute.For<IConfig>();
+            config.WebAppUrl.Returns(FakeUrl);
+            _builder = new DeadletterViewBuilder(_busMonitor, config);
+        }
+
+
+        void GivenThatTheBusMonitorReturnsAnOverview()
+        {
+            var overview = new Overview {
+                Queues = new List<Queue>
+                {
+                    new Queue {DeadLetterCount = 0, Name = "good.queue"},
+                    new Queue {DeadLetterCount = 1, Name = "bad.queue"},
+                    new Queue {DeadLetterCount = 10000, Name = "ohmahgerd.queue"}
+                },
+                Topics = new List<Topic>
+                {
+                    new Topic
+                    {
+                        Subscriptions = new List<Subscription>
+                        {
+                            new Subscription {DeadLetterCount = 0, Name = "good.sub.hi", TopicName = "hi"}
+                        }
+                    },
+                    new Topic
+                    {
+                        Subscriptions = new List<Subscription>()
+                    },
+                    new Topic
+                    {
+                        Subscriptions = new List<Subscription>
+                        {
+                            new Subscription {DeadLetterCount = 0, Name = "good.sub.bye", TopicName = "bye"},
+                            new Subscription {DeadLetterCount = 3, Name = "bad.sub.bye", TopicName = "bye"}
+                        }
+                    }
+                }
+            };
+            _busMonitor.GetOverview(Arg.Any<Boolean>()).Returns(overview);
+        }
+
+        void WhenBuildingModel()
+        {
+            _result = _builder.Build();
+        }
+
+        void ThenDeadlettersAreReturned()
+        {
+            _result.Deadletters.Count.ShouldBe(3);
+
+            _result.Deadletters.ShouldContain(dl => dl.Name == "bad.queue" && dl.DeadLetterCount == 1 && dl.Href == $"{FakeUrl}/#/queue/bad.queue");
+
+            _result.Deadletters.ShouldContain(dl => dl.Name == "ohmahgerd.queue" && dl.DeadLetterCount == 10000 && dl.Href == $"{FakeUrl}/#/queue/ohmahgerd.queue");
+
+            _result.Deadletters.ShouldContain(dl => dl.Name == "bad.sub.bye" && dl.DeadLetterCount == 3 && dl.Href == $"{FakeUrl}/#/topic/bye/bad.sub.bye");
+        }
+    }
+}

--- a/src/SbManager.Tests/Models/ViewModelBuilders/DeadletterVIewBuilderTests.cs
+++ b/src/SbManager.Tests/Models/ViewModelBuilders/DeadletterVIewBuilderTests.cs
@@ -81,11 +81,11 @@ namespace SbManager.Tests.Models.ViewModelBuilders
         {
             _result.Deadletters.Count.ShouldBe(3);
 
-            _result.Deadletters.ShouldContain(dl => dl.Name == "bad.queue" && dl.DeadLetterCount == 1 && dl.Href == $"{FakeUrl}/#/queue/bad.queue");
+            _result.Deadletters.ShouldContain(dl => dl.Name == "bad.queue" && dl.DeadLetterCount == 1 && dl.Href == FakeUrl + "/#/queue/bad.queue");
 
-            _result.Deadletters.ShouldContain(dl => dl.Name == "ohmahgerd.queue" && dl.DeadLetterCount == 10000 && dl.Href == $"{FakeUrl}/#/queue/ohmahgerd.queue");
+            _result.Deadletters.ShouldContain(dl => dl.Name == "ohmahgerd.queue" && dl.DeadLetterCount == 10000 && dl.Href == FakeUrl + "/#/queue/ohmahgerd.queue");
 
-            _result.Deadletters.ShouldContain(dl => dl.Name == "bad.sub.bye" && dl.DeadLetterCount == 3 && dl.Href == $"{FakeUrl}/#/topic/bye/bad.sub.bye");
+            _result.Deadletters.ShouldContain(dl => dl.Name == "bad.sub.bye" && dl.DeadLetterCount == 3 && dl.Href == FakeUrl + "/#/topic/bye/bad.sub.bye");
         }
     }
 }

--- a/src/SbManager.Tests/SbManager.Tests.csproj
+++ b/src/SbManager.Tests/SbManager.Tests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Extensions\StringExtensionsTests.cs" />
     <Compile Include="InternalCommandHandlers\RefreshCachedOverviewCommandHandlerTests.cs" />
     <Compile Include="Models\ModelExtensionsTests.cs" />
+    <Compile Include="Models\ViewModelBuilders\DeadletterVIewBuilderTests.cs" />
     <Compile Include="Models\ViewModelBuilders\OverviewModelBuilderTests.cs" />
     <Compile Include="Models\ViewModelBuilders\QueueModelBuilderTests.cs" />
     <Compile Include="Models\ViewModelBuilders\SubscriptionModelBuilderTests.cs" />

--- a/src/SbManager/HttpModules/V1/BusManagerModule.cs
+++ b/src/SbManager/HttpModules/V1/BusManagerModule.cs
@@ -35,6 +35,8 @@ namespace SbManager.HttpModules.V1
                    _commandSender.Send(new DeleteAllDeadLettersCommand());
                    return new { success = true };
                };
+            Get["/deadletters"] =
+                _ => _modelCreator.Build<DeadletterView>(); 
             Get["/topic/{tid}"] =
                 _ => _modelCreator.Build<Topic, TopicCriteria>(new TopicCriteria(To.String((object)_.tid)));
             Get["/queue/{qid}"] =

--- a/src/SbManager/Models/ViewModelBuilders/DeadletterViewBuilder.cs
+++ b/src/SbManager/Models/ViewModelBuilders/DeadletterViewBuilder.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using SbManager.BusHelpers;
+using SbManager.CQRS.ModelBuilders;
+using SbManager.Models.ViewModels;
+
+namespace SbManager.Models.ViewModelBuilders
+{
+    public class DeadletterViewBuilder : IModelBuilder<DeadletterView>
+    {
+        private readonly IBusMonitor _busMonitor;
+        private readonly string _baseUrl;
+
+        public DeadletterViewBuilder(IBusMonitor busMonitor, IConfig config)
+        {
+            _baseUrl = config.WebAppUrl;
+            _busMonitor = busMonitor;
+        }
+
+        public DeadletterView Build()
+        {
+            var overview = _busMonitor.GetOverview(true);
+            var deadletterQueues = overview.Queues.Where(q => q.DeadLetterCount > 0)
+                .Select(q => new Deadletter
+                {
+                    DeadLetterCount = q.DeadLetterCount,
+                    Name = q.Name,
+                    Href = CreateQueueUrl(q.Name)
+                });
+            var deadletterSubscription = overview.Topics.SelectMany(t => t.Subscriptions)
+                .Where(s => s.DeadLetterCount > 0).Select(s => new Deadletter
+                {
+                    DeadLetterCount = s.DeadLetterCount,
+                    Name = s.Name,
+                    Href = CreateSubscriptionUrl(s.TopicName, s.Name)
+                });
+
+            return new DeadletterView
+            {
+                Deadletters = deadletterQueues.Concat(deadletterSubscription).ToList()
+            };
+        }
+        private string CreateSubscriptionUrl(string topicName, string subName)
+        {
+            return $"{_baseUrl}/#/topic/{topicName}/{subName}";
+        }
+
+
+        private string CreateQueueUrl(string name)
+        {
+            return $"{_baseUrl}/#/queue/{name}";
+        }
+    }
+}

--- a/src/SbManager/Models/ViewModelBuilders/DeadletterViewBuilder.cs
+++ b/src/SbManager/Models/ViewModelBuilders/DeadletterViewBuilder.cs
@@ -41,13 +41,13 @@ namespace SbManager.Models.ViewModelBuilders
         }
         private string CreateSubscriptionUrl(string topicName, string subName)
         {
-            return $"{_baseUrl}/#/topic/{topicName}/{subName}";
+            return _baseUrl + "/#/topic/" + topicName + "/" + subName;
         }
 
 
         private string CreateQueueUrl(string name)
         {
-            return $"{_baseUrl}/#/queue/{name}";
+            return _baseUrl + "/#/queue/" + name;
         }
     }
 }

--- a/src/SbManager/Models/ViewModels/DeadletterView.cs
+++ b/src/SbManager/Models/ViewModels/DeadletterView.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace SbManager.Models.ViewModels
+{
+
+    public class DeadletterView
+    {
+        public DeadletterView()
+        {
+            Deadletters = new List<Deadletter>();
+        }
+        public IList<Deadletter> Deadletters { get; set; }
+    }
+
+    public class Deadletter
+    {
+        public string Name { get; set; }
+        public string Href { get; set; }
+        public long DeadLetterCount { get; set; }
+    }
+}

--- a/src/SbManager/SbManager.csproj
+++ b/src/SbManager/SbManager.csproj
@@ -215,12 +215,14 @@
     <Compile Include="InternalCommandHandlers\PublishMessageCommandHandler.cs" />
     <Compile Include="InternalCommandHandlers\SendMessageCommandHandler.cs" />
     <Compile Include="Models\ModelExtensions.cs" />
+    <Compile Include="Models\ViewModelBuilders\DeadletterViewBuilder.cs" />
     <Compile Include="Models\ViewModelBuilders\OverviewModelBuilder.cs" />
     <Compile Include="Models\ViewModelBuilders\SubscriptionMessagesBuilder.cs" />
     <Compile Include="Models\ViewModelBuilders\QueueMessagesBuilder.cs" />
     <Compile Include="Models\ViewModelBuilders\QueueModelBuilder.cs" />
     <Compile Include="Models\ViewModelBuilders\SubscriptionModelBuilder.cs" />
     <Compile Include="Models\ViewModelBuilders\TopicModelBuilder.cs" />
+    <Compile Include="Models\ViewModels\DeadletterView.cs" />
     <Compile Include="Models\ViewModels\Error.cs" />
     <Compile Include="Models\ViewModels\IHaveSettings.cs" />
     <Compile Include="Models\ViewModels\IHaveStatusInformation.cs" />


### PR DESCRIPTION
resolves #82

Sample response json body
```json
{
    "Deadletters": [
        {
            "Name": "q.messages.billing.v2.billingcommand",
            "Href": "http://+:8062/#/queue/q.messages.billing.v2.billingcommand",
            "DeadLetterCount": 4
        },
        {
            "Name": "q.gsf.getimagequeue",
            "Href": "http://+:8062/#/queue/q.getimagequeue",
            "DeadLetterCount": 2
        },
        {
            "Name": "q.getpackageitemcommand",
            "Href": "http://+:8062/#/queue/q.getpackageitemcommand",
            "DeadLetterCount": 2
        },
        {
            "Name": "manualfulfilment.endpoint.s3263829932",
            "Href": "http://+:8062/#/topic/t.common.provider.messages.v1/manualfulfilment.endpoint.s3263829932",
            "DeadLetterCount": 3
        },
        {
            "Name": "manualfulfillment.endpoi940054925",
            "Href": "http://+:8062/#/topic/t.common.provider.messages.v1/manualfulfillment.endpoi940054925",
            "DeadLetterCount": 2
        }]
}
```

The base url is from the appConfig `WebAppUrl`