### PR TITLE
Setup error page as the very first middleware in the OWIN pipeline

### DIFF
--- a/src/SbManager/Startup/OwinStartup.cs
+++ b/src/SbManager/Startup/OwinStartup.cs
@@ -23,6 +23,8 @@ namespace SbManager.Startup
 
         public void Configuration(IAppBuilder app)
         {
+            app.UseErrorPage();
+            
             //For serving up static files
             foreach (var staticDirectory in Constants.StaticDirectories)
             {
@@ -40,7 +42,6 @@ namespace SbManager.Startup
 
             app.Use(SupportReponseTypeByContentType); 
             app.UseNancy(a => { a.Bootstrapper = _nancyBootstrapper; });
-            app.UseErrorPage();
         }
 
         public static Task SupportReponseTypeByContentType(IOwinContext context, Func<Task> next)


### PR DESCRIPTION
The documentation for [`IAppBuilder.UseErrorPage()`][1] states this:
> Captures synchronous and asynchronous exceptions from the pipeline and generates HTML error responses.

If the error page is setup as the **last** middleware, it will not capture anything. The [`UseDeveloperExceptionPage`][2] equivalent feature of ASP.NET Core documentation is clear about this:

> Put `UseDeveloperExceptionPage` before any middleware you want to catch exceptions in, such as `app.UseMvc`.

<hr>

`IAppBuilder.UseErrorPage()` documentation also states this:
> Full error details are only displayed by default if 'host.AppMode' is set to 'development' in the IAppBuilder.Properties.

The easiest way to set the `host.AppMode` to `development` is to set the `VisualStudioVersion` environment variable to anything non whitespace. I guess that this is done automatically when running from Visual Studio. If you are using JetBrains Rider then adding `VisualStudioVersion=Rider` environment variable in the Run/Debug configuration will do the trick to get full error details with stack trace. (I found this by reading the [Microsoft.Owin.Hosting implementation][3].)

[1]: https://msdn.microsoft.com/en-us/library/dn253556(v=vs.113).aspx
[2]: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/error-handling?view=aspnetcore-2.1#the-developer-exception-page
[3]: https://github.com/aspnet/AspNetKatana/blob/v3.1.0/src/Microsoft.Owin.Hosting/Engine/HostingEngine.cs#L206-L212