### PR TITLE
Display error panel instead of silently logging

### DIFF
--- a/src/SbManager/Content/tmpl/directives/error.html
+++ b/src/SbManager/Content/tmpl/directives/error.html
@@ -1,0 +1,4 @@
+﻿<div class="panel panel-danger">
+    <div class="panel-heading">{{model.Error.Title || "Sorry, something went wrong"}}</div>
+    <div class="panel-body">{{model.Error.Summary || "An unexpected error occurred."}}</div>
+</div>

--- a/src/SbManager/Content/tmpl/manager/home.html
+++ b/src/SbManager/Content/tmpl/manager/home.html
@@ -7,7 +7,9 @@
 
     <loading ng-if="!model"></loading>
 
-    <div ng-if="model">
+    <error ng-if="model.Error"></error>
+
+    <div ng-if="model && !model.Error">
         <div class="row">
             <div class="col-lg-6">
                 <h2>Queues</h2>
@@ -29,8 +31,8 @@
         <nav class="container">
             <ul class="nav navbar-nav" ng-if="model">
                 <li><button class="btn btn-success" ng-click="refresh()"><i class="glyphicon glyphicon-refresh btn-sm"></i> Refresh</button></li>
-                <li><button class="btn btn-danger" ng-click="deleteAllDeadLetters()"><i class="glyphicon glyphicon-remove btn-sm"></i> Delete all Dead Letters</button></li>
-                <li class="hidden-xs"><button class="btn btn-danger" ng-click="deleteAll()"><i class="glyphicon glyphicon-remove btn-sm"></i> Delete all</button></li>
+                <li ng-if="!model.Error"><button class="btn btn-danger" ng-click="deleteAllDeadLetters()"><i class="glyphicon glyphicon-remove btn-sm"></i> Delete all Dead Letters</button></li>
+                <li ng-if="!model.Error" class="hidden-xs"><button class="btn btn-danger" ng-click="deleteAll()"><i class="glyphicon glyphicon-remove btn-sm"></i> Delete all</button></li>
             </ul>
         </nav>
     </div>

--- a/src/SbManager/Content/tmpl/manager/status.html
+++ b/src/SbManager/Content/tmpl/manager/status.html
@@ -7,7 +7,9 @@
 
     <loading ng-if="!model"></loading>
 
-    <div ng-if="model">
+    <error ng-if="model.Error"></error>
+
+    <div ng-if="model && !model.Error">
         <div class="row status">
             <h2>Dashboard</h2>
             <queuelength active="{{model.TotalActiveMessages}}" dead="{{model.TotalDeadLetters}}" scheduled="{{model.TotalScheduledMessages}}" multiline="true" />

--- a/src/SbManager/Scripts/manager/directives.js
+++ b/src/SbManager/Scripts/manager/directives.js
@@ -20,6 +20,12 @@ $app.directive('loading', function () {
         templateUrl: window.applicationBasePath + '/Content/tmpl/directives/loading.html'
     };
 });
+$app.directive('error', function () {
+    return {
+        restrict: 'EA',
+        templateUrl: window.applicationBasePath + '/Content/tmpl/directives/error.html'
+    };
+});
 $app.directive('messagingentity',['messageTypeConstants', function (messageTypeConstants) {
     return {
         restrict: 'EA',

--- a/src/SbManager/Scripts/manager/homeController.js
+++ b/src/SbManager/Scripts/manager/homeController.js
@@ -9,12 +9,7 @@
             $scope.topicsWithDeadlettersCount = d.data.Topics.reduce((c, t) => c + (t.DeadLetterCount ? 1 : 0), 0);
         })
         .catch(function (jqXHR) {
-            if (jqXHR.data == "") {
-                $log.error("Undefined Error");
-            } else {
-                var err = jqXHR.data;
-                $log.error(err.StatusCode + ": " + err.Message);
-            }
+            $scope.model = {Error: jqXHR.data};
         });
     };
     $scope.refresh();

--- a/src/SbManager/Scripts/manager/statusController.js
+++ b/src/SbManager/Scripts/manager/statusController.js
@@ -8,12 +8,7 @@
             $scope.time = currentTime.getHours() + ":" + ('0' + currentTime.getMinutes()).slice(-2);
         })
         .catch(function (jqXHR) {
-            if (jqXHR.data == "") {
-                alert("Undefined Error");
-            } else {
-                var err = jqXHR.data;
-                alert("ERROR " + err.StatusCode + ": " + err.Message);
-            } 
+            $scope.model = {Error: jqXHR.data};
         });
     };
     $scope.refresh();


### PR DESCRIPTION
Pull request #89 changed error handling from alert() to log() because using window.alert for errors stops the refresh on monitoring displays.

Unfortunately, this is a nightmare from a user experience point of view on non-monitoring displays because in case of error, the "Loading…" screen stays forever.

This pull request addresses this issue by displaying an error panel in case of error.